### PR TITLE
🔥 HOTFIX: If statement wrong and typos

### DIFF
--- a/PhantomTranslate.py
+++ b/PhantomTranslate.py
@@ -244,7 +244,7 @@ else:
                 verbose_output("File converted")
                 f.write(file_output)
                 filename = f.name
-        if sys.platform is "linux":
+        if sys.platform == "linux":
             os.system("unix2dos -o " + filename)
             verbose_output("Converted file do dos format: " + filename)
     print("All converted.")

--- a/PhantomTranslate.py
+++ b/PhantomTranslate.py
@@ -246,7 +246,7 @@ else:
                 filename = f.name
         if sys.platform == "linux":
             os.system("unix2dos -o " + filename)
-            verbose_output("Converted file do dos format: " + filename)
+            verbose_output("Converted file to dos format: " + filename)
     print("All converted.")
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We use it to help translating with Transifex.
 | `-i PATH` | `--input=PATH` | The path to the file to be converted. |
 | `-o PATH` | `--output=PATH` | The path to the file where the converted data should be saved.|
 | `-f i18n / ph` | `--format=i18n / ph` | Choose the input file type, if it is a i18n JSON file or an PhantomBot lang file. |
-| `-f f / d` | `--type=f / d` | Choose if you input an how directory or one file. |
+| `-t f / d` | `--type=f / d` | Choose if you input an how directory or one file. |
 | `-v` | `--verbose` | Outputs more for nerds |
 | `-q` | `--quiet` | Psst... *[Default]* |
 


### PR DESCRIPTION
On the file conversion to dos format was an `is` else then an `==`.
Fixed typo in Script and README.md